### PR TITLE
fix encoding issue when using chinese query string

### DIFF
--- a/src/Url.php
+++ b/src/Url.php
@@ -14,7 +14,7 @@ class Url
 
     public static function unparse_str($array)
     {
-        return '?' . urldecode(http_build_query($array));//preg_replace('/%5B[0-9]+%5D/simU', '[]', http_build_query($array));
+        return '?' . preg_replace('/%5B[0-9]+%5D/simU', '%5B%5D', http_build_query($array));
     }
 
     public function set($url)


### PR DESCRIPTION
Sample Case:  
        http://localhost/list?search=1&name=%E5%85%B8&page=3
Then, the name column will be broken in pagination 

So the previous change should be rollback, and the  '[]' in preg_replace() should be '%5B%5D' .