### PR TITLE
bugfix: modifyButton and autoComplete don't work in create success page

### DIFF
--- a/src/DataEdit/DataEdit.php
+++ b/src/DataEdit/DataEdit.php
@@ -224,7 +224,7 @@ class DataEdit extends DataForm
         //show
         if ($this->status == "show") {
 
-            //  bugfix: 新建对象成功的页面里,修改按钮的参数不对. 这样修改不会影响 item/?show 页面的按钮参数.
+            //  in create success page, url's "insert=1" should be replace to "modify=xxx"
             $this->url->remove('insert');
             $this->url->append('modify', $this->model->id);
 

--- a/src/DataEdit/DataEdit.php
+++ b/src/DataEdit/DataEdit.php
@@ -224,6 +224,10 @@ class DataEdit extends DataForm
         //show
         if ($this->status == "show") {
 
+            //  bugfix: 新建对象成功的页面里,修改按钮的参数不对. 这样修改不会影响 item/?show 页面的按钮参数.
+            $this->url->remove('insert');
+            $this->url->append('modify', $this->model->id);
+
             $this->link($this->url->replace('show' . $this->cid, 'modify' . $this->cid)->get(), trans('rapyd::rapyd.modify'), $showButtonPosition);
 
         }

--- a/src/DataForm/Field/Autocomplete.php
+++ b/src/DataForm/Field/Autocomplete.php
@@ -130,8 +130,8 @@ class Autocomplete extends Field
                     $output = "";
                 } else {
                     if ($this->relation != null) {
-                        $name = $this->rel_field;
-                        $value = @$this->relation->get()->first()->$name;
+                        list($table, $name) = explode('_', $this->name);
+                        $value = $this->model->$table->$name;
                     } else {
                         $value = $this->value;
                     }

--- a/src/DataForm/Field/Autocomplete.php
+++ b/src/DataForm/Field/Autocomplete.php
@@ -171,6 +171,9 @@ class Autocomplete extends Field
                                 complete: function(response){
                                     response.responseJSON.forEach(function (item) {
                                         blod_{$this->name}.valueCache[item.{$this->record_label}] = item.{$this->record_id};
+                                        if ( item.{$this->record_label} == $('#auto_{$this->name}').val() ) {
+                                            $('#{$this->name}').val(item.{$this->record_id});
+                                        }
                                     });
                                 }
                             }
@@ -196,10 +199,7 @@ class Autocomplete extends Field
                         function (e,data) {
                             if ('{$this->must_match}') {
                                 var _label = $.trim($(this).val());
-                                if ( !(_label in blod_{$this->name}.valueCache) ) {
-                                    $('#{$this->name}').val('');
-                                    $(this).val('');
-                                } else {
+                                if ( _label in blod_{$this->name}.valueCache ) {
                                     //Fill data to hidden input, when direct copy data to input without choose from auto-complete results.
                                     $('#{$this->name}').val(blod_{$this->name}.valueCache[_label]);
                                 }


### PR DESCRIPTION
1. bugfix: 新建对象成功的页面里,修改按钮的参数不对. 这样修改不会影响 item/?show 页面的按钮参数.
2. 另外，代码并没有格式化。因为源码中长代码太多。格式化之后会折断很多地方，倾向于以后单独格式化。