### PR TITLE
兼容 laravel 5.4

### DIFF
--- a/src/DataForm/Field/Daterange.php
+++ b/src/DataForm/Field/Daterange.php
@@ -12,10 +12,26 @@ class Daterange extends Date
     public $multiple = true;
     public $clause = "wherebetween";
     
+    protected $suffix_from = '-from';
+    protected $suffix_to = '-to';
+
     public function getNewValue()
     {
+        $this->values = [];
+
+        $origin = $this->name;
+        $this->name = $origin. $this->suffix_from;
+        $this->new_value = null;
         Field::getNewValue();
-        $this->values = explode($this->serialization_sep, $this->new_value);
+        $this->values [] = $this->new_value;
+
+        $this->name = $origin. $this->suffix_to;
+        $this->new_value = null;
+        Field::getNewValue();
+        $this->values [] = $this->new_value;
+
+        $this->name = $origin;
+
         foreach ($this->values as $value) {
             $values[] = $this->humanDateToIso($value);
         }
@@ -28,8 +44,21 @@ class Daterange extends Date
 
     public function getValue()
     {
+        $this->values = [];
+
+        $origin = $this->name;
+        $this->name = $origin. $this->suffix_from;
+        $this->new_value = null;
         Field::getValue();
-        $this->values = explode($this->serialization_sep, $this->value);
+        $this->values [] = $this->value;
+
+        $this->name = $origin. $this->suffix_to;
+        $this->new_value = null;
+        Field::getValue();
+        $this->values [] = $this->value;
+
+        $this->name = $origin;
+
         foreach ($this->values as $value) {
             $values[] = $this->isoDateToHuman($value);
         }
@@ -70,9 +99,9 @@ class Daterange extends Date
                 unset($this->attributes['id']);
                 //$this->attributes['class'] = "form-control";
 
+                $from = Form::text($this->name . $this->suffix_from, @$this->values[0], $this->attributes);
+                $to = Form::text($this->name . $this->suffix_to, @$this->values[1], $this->attributes);
 
-                $from = Form::text($this->name . '[from]', @$this->values[0], $this->attributes);
-                $to = Form::text($this->name . '[to]', @$this->values[1], $this->attributes);
 
                 $output = '
                             <div id="range_' . $this->name . '_container">

--- a/src/DataForm/Field/Daterange.php
+++ b/src/DataForm/Field/Daterange.php
@@ -11,7 +11,7 @@ class Daterange extends Date
     public $type = "daterange";
     public $multiple = true;
     public $clause = "wherebetween";
-    
+
     protected $suffix_from = '-from';
     protected $suffix_to = '-to';
 

--- a/src/DataForm/Field/Field.php
+++ b/src/DataForm/Field/Field.php
@@ -129,7 +129,11 @@ abstract class Field extends Widget
 
             if (is_a(@$this->relation, 'Illuminate\Database\Eloquent\Relations\BelongsToMany')){
 
-                $this->rel_other_key = $this->relation->getQualifiedRelatedKeyName();
+                if (method_exists($this->relation, 'getOtherKey')) {
+                    $this->rel_other_key = $this->relation->getOtherKey();
+                }else{
+                    $this->rel_other_key = $this->relation->getQualifiedRelatedKeyName();
+                }
 
             }
 

--- a/src/DataForm/Field/Field.php
+++ b/src/DataForm/Field/Field.php
@@ -129,7 +129,7 @@ abstract class Field extends Widget
 
             if (is_a(@$this->relation, 'Illuminate\Database\Eloquent\Relations\BelongsToMany')){
 
-                $this->rel_other_key = $this->relation->getOtherKey();
+                $this->rel_other_key = $this->relation->getQualifiedRelatedKeyName();
 
             }
 


### PR DESCRIPTION
## 修改 Daterange 的 field name

in `\Collective\Html\FormBuilder::getValueAttribute` 

![image](https://user-images.githubusercontent.com/4499674/28664045-aa21e27c-72f1-11e7-8eb3-9cc3be88a508.png)

laravelcollective/html 5.4 渲染daterange时这里会从request里会取到array，填充表单就会挂掉

laravel 5.4 依赖 laravelcollective/html 5.4

## getOtherKey() 改名